### PR TITLE
Improves commands' help messages

### DIFF
--- a/bin/accloudtant
+++ b/bin/accloudtant
@@ -9,12 +9,12 @@ def cli():
     pass
 
 
-@cli.command('list')
+@cli.command('list', short_help='prints current price lists')
 def price_list():
     click.echo(Prices())
 
 
-@cli.command()
+@cli.command(short_help='provides price/usage reports')
 def report():
     click.echo(Reports())
 


### PR DESCRIPTION
Fixes #70 by providing this output:

```
Usage: accloudtant [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  list    prints current price lists
  report  provides price/usage reports
```
