### PR TITLE
Fix web prices load for on demand instances

### DIFF
--- a/accloudtant/aws/prices.py
+++ b/accloudtant/aws/prices.py
@@ -26,8 +26,8 @@ from accloudtant.utils import fix_lazy_json
 class Prices(object):
     def __init__(self):
         with warnings.catch_warnings(record=True) as price_warnings:
-            curr_url = 'http://aws.amazon.com/ec2/pricing/'
-            prev_url = 'http://aws.amazon.com/ec2/previous-generation/'
+            curr_url = 'https://aws.amazon.com/ec2/pricing/on-demand/'
+            prev_url = 'https://aws.amazon.com/ec2/previous-generation/'
             self.prices = process_ec2(curr_url)
             prices_prev = process_ec2(prev_url)
             for kind in self.prices:
@@ -57,7 +57,7 @@ def print_prices(instances=None, region='us-east-1'):
     if 'AWS_DEFAULT_REGION' in environ:
         region = environ['AWS_DEFAULT_REGION']
     empty_ri = {
-        'yrTerm1': {
+        'yrTerm1Standard': {
             'noUpfront': {
                 'effectiveHourly': None,
             },
@@ -68,7 +68,7 @@ def print_prices(instances=None, region='us-east-1'):
                 'effectiveHourly': None,
             },
         },
-        'yrTerm3': {
+        'yrTerm3Standard': {
             'noUpfront': {
                 'effectiveHourly': None,
             },
@@ -93,8 +93,8 @@ def print_prices(instances=None, region='us-east-1'):
             instance_size = instances[ec2_kind][region][size]
             on_demand = instance_size['od']
             reserved_prices = instance_size.get('ri', empty_ri)
-            rsrvd_1yr = reserved_prices['yrTerm1']
-            rsrvd_3yr = reserved_prices['yrTerm3']
+            rsrvd_1yr = reserved_prices['yrTerm1Standard']
+            rsrvd_3yr = reserved_prices['yrTerm3Standard']
             no_upfront = 'noUpfront'
             partial_upfront = 'partialUpfront'
             all_upfront = 'allUpfront'
@@ -286,9 +286,9 @@ def process_data_transfer(data, js_name, instances=None):
         region = region_data['region']
         init_region(instances[generic['kind']], region)
         section = instances[generic['kind']][region]
-        section['regional'] = region_data['regionalDataTransfer']
-        section['ELB'] = region_data['elasticLBDataTransfer']
-        section['AZ'] = region_data['azDataTransfer']
+        section['regional'] = region_data.get('regionalDataTransfer', {})
+        section['ELB'] = region_data.get('elasticLBDataTransfer', {})
+        section['AZ'] = region_data.get('azDataTransfer', {})
         process_data_xfer_types(region_data['types'], section)
     return instances
 

--- a/accloudtant/aws/reports.py
+++ b/accloudtant/aws/reports.py
@@ -76,7 +76,12 @@ class Reports(object):
             instance.current = float(instance_size['od'])
             if instance.state == 'stopped':
                 instance.current = 0.0
-            instance_all_upfront = instance_size['ri']['yrTerm3']['allUpfront']
+            try:
+                instance_all_upfront = instance_size['ri']['yrTerm3Standard']['allUpfront']
+            except KeyError:
+                instance_all_upfront = {
+                    'effectiveHourly': 0.0,
+                }
             instance.best = float(instance_all_upfront['effectiveHourly'])
             for reserved in self.reserved_instances:
                 if instance.match_reserved_instance(reserved):

--- a/tests/aws/test_prices.py
+++ b/tests/aws/test_prices.py
@@ -208,7 +208,7 @@ def check_reserved_regions(instance_kinds):
             instance_size = instance_kinds[region]['t2.micro']
             assert('ri' in instance_size)
             instance_reserved = instance_size['ri']
-            terms = ['yrTerm1', 'yrTerm3']
+            terms = ['yrTerm1Standard', 'yrTerm3Standard']
             assert(term in instance_reserved for term in terms)
             for term in terms:
                 for purchase_opt in ['partialUpfront', 'allUpfront']:
@@ -217,8 +217,8 @@ def check_reserved_regions(instance_kinds):
                     assert('upfront' in purchase_parts)
                     assert('monthlyStar' in purchase_parts)
                     assert('effectiveHourly' in purchase_parts)
-            assert('noUpfront' in instance_reserved['yrTerm1'])
-            no_upfront = instance_reserved['yrTerm1']['noUpfront']
+            assert('noUpfront' in instance_reserved['yrTerm1Standard'])
+            no_upfront = instance_reserved['yrTerm1Standard']['noUpfront']
             assert(no_upfront['upfront'] == '0')
             assert(no_upfront['monthlyStar'] == '6.57')
             assert(no_upfront['effectiveHourly'] == '0.009')
@@ -235,7 +235,7 @@ def test_process_reserved(monkeypatch, mock_process_generic):
                 'instanceTypes': [{
                   'type': 't2.micro',
                   'terms': [{
-                      'term': 'yrTerm1',
+                      'term': 'yrTerm1Standard',
                       'purchaseOptions': [{
                           'purchaseOption': 'noUpfront',
                           'savingsOverOD': '31%',
@@ -277,7 +277,7 @@ def test_process_reserved(monkeypatch, mock_process_generic):
                               }, ],
                           }, ]
                       }, {
-                      'term': 'yrTerm3',
+                      'term': 'yrTerm3Standard',
                       'purchaseOptions': [{
                           'purchaseOption': 'partialUpfront',
                           'savingsOverOD': '53%',
@@ -312,7 +312,7 @@ def test_process_reserved(monkeypatch, mock_process_generic):
                 'instanceTypes': [{
                   'type': 't2.micro',
                   'terms': [{
-                      'term': 'yrTerm1',
+                      'term': 'yrTerm1Standard',
                       'purchaseOptions': [{
                           'purchaseOption': 'noUpfront',
                           'savingsOverOD': '31%',
@@ -354,7 +354,7 @@ def test_process_reserved(monkeypatch, mock_process_generic):
                               }, ],
                           }, ]
                       }, {
-                      'term': 'yrTerm3',
+                      'term': 'yrTerm3Standard',
                       'purchaseOptions': [{
                           'purchaseOption': 'partialUpfront',
                           'savingsOverOD': '53%',
@@ -868,7 +868,7 @@ def test_print_prices(capsys):
                 'g2.2xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -885,7 +885,7 @@ def test_print_prices(capsys):
                                 'effectiveHourly': '0.5121',
                                 },
                             },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',
@@ -905,7 +905,7 @@ def test_print_prices(capsys):
                 'c3.8xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -922,7 +922,7 @@ def test_print_prices(capsys):
                                 'effectiveHourly': '0.5121',
                                 },
                             },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',
@@ -944,7 +944,7 @@ def test_print_prices(capsys):
                 'g2.2xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -961,7 +961,7 @@ def test_print_prices(capsys):
                                 'effectiveHourly': '0.5121',
                                 },
                             },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',
@@ -981,7 +981,7 @@ def test_print_prices(capsys):
                 'c3.8xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -998,7 +998,7 @@ def test_print_prices(capsys):
                                 'effectiveHourly': '0.5121',
                                 },
                             },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',
@@ -1152,7 +1152,7 @@ def test_prices(capsys, monkeypatch, process_ec2):
                 'g2.2xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -1169,7 +1169,7 @@ def test_prices(capsys, monkeypatch, process_ec2):
                                 'effectiveHourly': '0.5121',
                                 },
                             },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',
@@ -1189,7 +1189,7 @@ def test_prices(capsys, monkeypatch, process_ec2):
                 'c3.8xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -1206,7 +1206,7 @@ def test_prices(capsys, monkeypatch, process_ec2):
                                 'effectiveHourly': '0.5121',
                                 },
                             },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',
@@ -1228,7 +1228,7 @@ def test_prices(capsys, monkeypatch, process_ec2):
                 'g2.2xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -1245,7 +1245,7 @@ def test_prices(capsys, monkeypatch, process_ec2):
                                 'effectiveHourly': '0.5121',
                                 },
                             },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',
@@ -1265,7 +1265,7 @@ def test_prices(capsys, monkeypatch, process_ec2):
                 'c3.8xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -1282,7 +1282,7 @@ def test_prices(capsys, monkeypatch, process_ec2):
                                 'effectiveHourly': '0.5121',
                                 },
                             },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',
@@ -1448,7 +1448,7 @@ def test_prices_with_warning(capsys, monkeypatch, process_ec2):
                 'g2.2xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -1465,7 +1465,7 @@ def test_prices_with_warning(capsys, monkeypatch, process_ec2):
                                 'effectiveHourly': '0.5121',
                                 },
                             },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',
@@ -1485,7 +1485,7 @@ def test_prices_with_warning(capsys, monkeypatch, process_ec2):
                 'c3.8xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -1502,7 +1502,7 @@ def test_prices_with_warning(capsys, monkeypatch, process_ec2):
                                 'effectiveHourly': '0.5121',
                                 },
                             },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',
@@ -1524,7 +1524,7 @@ def test_prices_with_warning(capsys, monkeypatch, process_ec2):
                 'g2.2xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -1541,7 +1541,7 @@ def test_prices_with_warning(capsys, monkeypatch, process_ec2):
                                 'effectiveHourly': '0.5121',
                                 },
                             },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',
@@ -1561,7 +1561,7 @@ def test_prices_with_warning(capsys, monkeypatch, process_ec2):
                 'c3.8xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -1578,7 +1578,7 @@ def test_prices_with_warning(capsys, monkeypatch, process_ec2):
                                 'effectiveHourly': '0.5121',
                                 },
                             },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',

--- a/tests/aws/test_reports.py
+++ b/tests/aws/test_reports.py
@@ -394,7 +394,7 @@ def test_reports_table(capsys, monkeypatch, ec2_resource, ec2_client,
                 'c3.8xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -411,7 +411,7 @@ def test_reports_table(capsys, monkeypatch, ec2_resource, ec2_client,
                                 'effectiveHourly': '0.5021',
                             },
                         },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',
@@ -435,7 +435,7 @@ def test_reports_table(capsys, monkeypatch, ec2_resource, ec2_client,
                 'r2.8xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -452,7 +452,7 @@ def test_reports_table(capsys, monkeypatch, ec2_resource, ec2_client,
                                 'effectiveHourly': '0.5121',
                             },
                         },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10233.432',
                                 'monthlyStar': '0',
@@ -476,7 +476,7 @@ def test_reports_table(capsys, monkeypatch, ec2_resource, ec2_client,
                 'r2.8xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -493,7 +493,7 @@ def test_reports_table(capsys, monkeypatch, ec2_resource, ec2_client,
                                 'effectiveHourly': '0.5121',
                             },
                         },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',
@@ -517,7 +517,7 @@ def test_reports_table(capsys, monkeypatch, ec2_resource, ec2_client,
                 't1.micro': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -534,7 +534,7 @@ def test_reports_table(capsys, monkeypatch, ec2_resource, ec2_client,
                                 'effectiveHourly': '0.5121',
                             },
                         },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',
@@ -554,7 +554,7 @@ def test_reports_table(capsys, monkeypatch, ec2_resource, ec2_client,
                 'r2.8xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -571,7 +571,7 @@ def test_reports_table(capsys, monkeypatch, ec2_resource, ec2_client,
                                 'effectiveHourly': '0.5121',
                             },
                         },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',
@@ -1021,7 +1021,7 @@ def test_reports_csv(capsys, monkeypatch, ec2_resource, ec2_client,
                 'c3.8xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -1038,7 +1038,7 @@ def test_reports_csv(capsys, monkeypatch, ec2_resource, ec2_client,
                                 'effectiveHourly': '0.5021',
                             },
                         },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',
@@ -1062,7 +1062,7 @@ def test_reports_csv(capsys, monkeypatch, ec2_resource, ec2_client,
                 'r2.8xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -1079,7 +1079,7 @@ def test_reports_csv(capsys, monkeypatch, ec2_resource, ec2_client,
                                 'effectiveHourly': '0.5121',
                             },
                         },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10233.432',
                                 'monthlyStar': '0',
@@ -1103,7 +1103,7 @@ def test_reports_csv(capsys, monkeypatch, ec2_resource, ec2_client,
                 'r2.8xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -1120,7 +1120,7 @@ def test_reports_csv(capsys, monkeypatch, ec2_resource, ec2_client,
                                 'effectiveHourly': '0.5121',
                             },
                         },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',
@@ -1144,7 +1144,7 @@ def test_reports_csv(capsys, monkeypatch, ec2_resource, ec2_client,
                 't1.micro': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -1161,7 +1161,7 @@ def test_reports_csv(capsys, monkeypatch, ec2_resource, ec2_client,
                                 'effectiveHourly': '0.5121',
                             },
                         },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',
@@ -1181,7 +1181,7 @@ def test_reports_csv(capsys, monkeypatch, ec2_resource, ec2_client,
                 'r2.8xlarge': {
                     'storageGB': '60 SSD',
                     'ri': {
-                        'yrTerm1': {
+                        'yrTerm1Standard': {
                             'noUpfront': {
                                 'upfront': '0',
                                 'monthlyStar': '446.03',
@@ -1198,7 +1198,7 @@ def test_reports_csv(capsys, monkeypatch, ec2_resource, ec2_client,
                                 'effectiveHourly': '0.5121',
                             },
                         },
-                        'yrTerm3': {
+                        'yrTerm3Standard': {
                             'allUpfront': {
                                 'upfront': '10234',
                                 'monthlyStar': '0',


### PR DESCRIPTION
Following approach from @arunjayanth in #117,
this changes the URL from which it downloads
prices, uses the new keys. and handles the lack
of expected keys.

Unluckily, it doesn't help with the reserved prices.