### PR TITLE
Fix Cloudfront Bandwidth calculations

### DIFF
--- a/accloudtant/aws/cloudfront/__init__.py
+++ b/accloudtant/aws/cloudfront/__init__.py
@@ -2,14 +2,13 @@ def omit(usage_record):
     return is_data_transfer(usage_record.type) \
         or usage_record.type.endswith("Static") \
         or usage_record.type.endswith("Dynamic") \
-        or usage_record.type.endswith("Bytes-HTTP-Proxy") \
-        or "DataTransfer" in usage_record.type
+        or usage_record.type.endswith("Bytes-HTTPS-Proxy") \
+        or usage_record.type.endswith("Bytes-HTTP-Proxy")
 
 
 def is_data_transfer(usage_type):
     return False
 
 
-def is_bandwidth(usage_record):
-    return usage_record.type.endswith("DataTransfer-Out-Bytes") \
-        or usage_record.type.endswith("DataTransfer-Out-OBytes")
+def is_bandwidth(concept):
+    return "DataTransfer" in concept

--- a/accloudtant/aws/route53/__init__.py
+++ b/accloudtant/aws/route53/__init__.py
@@ -6,5 +6,5 @@ def is_data_transfer(usage_type):
     return False
 
 
-def is_bandwidth(usage_record):
+def is_bandwidth(concept):
     return False

--- a/accloudtant/aws/s3/__init__.py
+++ b/accloudtant/aws/s3/__init__.py
@@ -6,5 +6,5 @@ def is_data_transfer(usage_type):
     return "DataTransfer" in usage_type or "CloudFront" in usage_type
 
 
-def is_bandwidth(usage_record):
+def is_bandwidth(concept):
     return False

--- a/accloudtant/usage_record.py
+++ b/accloudtant/usage_record.py
@@ -72,11 +72,3 @@ class UsageRecord(object):
         if self.service in SERVICES:
             return SERVICES[self.service]["module"].is_bandwidth(self)
         return False
-
-    def clone(self):
-        return UsageRecord({
-            "Service": self.service,
-            " UsageType": "Bandwidth",
-            " UsageValue": self.value,
-            " Resource": self.resource,
-        })

--- a/accloudtant/usage_records.py
+++ b/accloudtant/usage_records.py
@@ -1,3 +1,6 @@
+from accloudtant.usage_record import SERVICES
+
+
 class UsageRecords(object):
     def __init__(self, data=None):
         if data is None:
@@ -18,9 +21,6 @@ class UsageRecords(object):
         if new.area is not None:
             self.resource_areas[new.resource] = new.area
         self._data.append(new)
-        if new.is_bandwidth:
-            new_bandwidth = new.clone()
-            self._data.append(new_bandwidth)
 
     def areas(self):
         areas = {}
@@ -56,13 +56,16 @@ class UsageRecords(object):
             for area, entries in areas.areas():
                 services[service][area] = []
                 for concept in set([entry.type for entry in entries if not entry.omit]):
+                    output_concept = concept
                     total_calc = default_total_calc
                     if concept.endswith("ByteHrs"):
                         total_calc = bytehrs_total_calc
-                    elif concept.endswith("Bytes") or concept == "Bandwidth":
+                    elif concept.endswith("Bytes"):
                         total_calc = bytes_total_calc
+                    if SERVICES[service]["module"].is_bandwidth(concept):
+                        output_concept = "Bandwidth"
                     services[service][area].append((
-                        concept,
+                        output_concept,
                         "{:.3f}".format(total_calc(
                             [e for e in entries if e.type == concept and not e.omit])),
                         unit(concept),

--- a/tests/test_usage_records.py
+++ b/tests/test_usage_records.py
@@ -38,7 +38,7 @@ from accloudtant import load_data
                     "Europe": [
                         "EU-Requests-Tier1 5733.000 Requests",
                         "EU-Requests-Tier2-HTTPS 7998.000 Requests",
-                        "Bandwidth 35.058 GB",
+                        "Bandwidth 8.388 GB",
                     ],
                     "Global": [
                         "Invalidations 2.000 URL",
@@ -48,6 +48,7 @@ from accloudtant import load_data
                         "US-Requests-Tier1 523.000 Requests",
                         "US-Requests-Tier2-HTTPS 1287.000 Requests",
                         "Bandwidth 4.541 GB",
+                        "Bandwidth 0.000 GB",
                     ],
                 },
             },


### PR DESCRIPTION
Bandwidth concepts in the output were wrong. The problem was that
DataTransfer was omitted. Concept adjusting was also needed to
fix. The bandwidth identification was also simplified.